### PR TITLE
typos fixed

### DIFF
--- a/manuscript/05-graphql-react/index.md
+++ b/manuscript/05-graphql-react/index.md
@@ -476,7 +476,7 @@ You performed your first GraphQL query in a React application, a plain HTTP POST
 
 ### GraphQL Nested Objects in React
 
-Next, we'll request a nested object for the organization. Since the application will eventually show the issues in a repository, you should fetch a repository of an organization as the next step. Remember, a query reaches into the GraphQL graph, so we can nest the `repository` field in the `organization` when the schema defined the relationship between these two entities.
+Next, we'll request a nested object for the organization. Since the application will eventually show the issues in a repository, you should fetch a repository of an organization as the next step. Remember, a query reaches into the GraphQL graph, so we can nest the `repository` field in the `organization` when the schema defines the relationship between these two entities.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -583,7 +583,7 @@ const GET_ISSUES_OF_REPOSITORY = `
 `;
 ~~~~~~~
 
-You can also request an id for each issue using the `id` field on the issue's `node` field, to use a `key` attribute for your list of rendered items in the component, which is considered [best practice in React](https://reactjs.org/docs/lists-and-keys.html). Remember to adjust the name of the query variable when its used to perform the request.
+You can also request an id for each issue using the `id` field on the issue's `node` field, to use a `key` attribute for your list of rendered items in the component, which is considered [best practice in React](https://reactjs.org/docs/lists-and-keys.html). Remember to adjust the name of the query variable when it's used to perform the request.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -738,7 +738,7 @@ class App extends Component {
 
 Since the split returns an array of values and it is assumed that there is only one slash in the path, the array should consist of two values: the organization and the repository. That's why it is convenient to use a JavaScript array destructuring to pull out both values from an array in the same line.
 
-Note that the application is not built for to be robust, but is intended only as a learning experience. It is unlikely anyone will ask a user to input the organization and repository with a different pattern than *organization/repository*, so there is no validation included yet. Still, it is a good foundation for you to gain experience with the concepts.
+Note that the application is not built to be robust, it is only intended as a learning experience. It is unlikely anyone will ask a user to input the organization and repository with a different pattern than *organization/repository*, so there is no validation included yet. Still, it is a good foundation for you to gain experience with the concepts.
 
 If you want to go further, you can extract the first part of the class method to its own function, which uses axios to send a request with the query and return a promise. The promise can be used to resolve the result into the local state, using `this.setState()` in the `then()` resolver block of the promise.
 
@@ -772,7 +772,7 @@ class App extends Component {
 }
 ~~~~~~~
 
-You can always split your applications into parts, be they functions or components, to make them concise, readable, reusable and [testable](https://www.robinwieruch.de/react-testing-tutorial/). The function that is passed to `this.setState()` can be extracted as higher-order function. It has to be a higher-order function, because you need to pass the result of the promise, but also provide a function for the `this.setState()` method.
+You can always split your applications into parts, be they functions or components, to make them concise, readable, reusable and [testable](https://www.robinwieruch.de/react-testing-tutorial/). The function that is passed to `this.setState()` can be extracted as a higher-order function. It has to be a higher-order function, because you need to pass the result of the promise, but also provide a function for the `this.setState()` method.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -1174,7 +1174,7 @@ const GET_ISSUES_OF_REPOSITORY = `
 `;
 ~~~~~~~
 
-In the previous template string, the `cursor` is passed as variable to the query and used as `after` argument for the list field. The variable is not enforced though, because there is no exclamation mark next to it, so it can be `undefined`. This happens for the initial page request for a paginated list, when you only want to fetch the first page. Further, the argument `last` has been changed to `first` for the `issues` list field, because there won't be another page after you fetched the last item in the initial request. Thus, you have to start with the first items of the list to fetch more items until you reach the end of the list.
+In the previous template string, the `cursor` is passed as variable to the query and used as an `after` argument for the list field. The variable is not enforced though, because there is no exclamation mark next to it, so it can be `undefined`. This happens for the initial page request for a paginated list, when you only want to fetch the first page. Further, the argument `last` has been changed to `first` for the `issues` list field, because there won't be another page after you fetched the last item in the initial request. Thus, you have to start with the first items of the list to fetch more items until you reach the end of the list.
 
 That's it for fetching the next page of a paginated list with GraphQL in React, except one final step. Nothing updates the local state of the App component about a page of issues yet, so there are still only the issues from the initial request. You want to merge the old pages of issues with the new page of issues in the local state of the App component, while keeping the organization and repository information in the deeply nested state object intact. The perfect time for doing this is when the promise for the query resolves. You already extracted it as a function outside of the App component, so you can use this place to handle the incoming result and return a result with your own structure and information. Keep in mind that the incoming result can be an initial request when the App component mounts for the first time, or after a request to fetch more issues happens, such as when the "More" button is clicked.
 
@@ -1628,4 +1628,4 @@ I am looking forward to introducing Apollo as a GraphQL client library to your R
 
 You can find the final [repository on GitHub](https://github.com/rwieruch/react-graphql-github-vanilla). The repository showcases most of the exercise tasks too. The application is not feature complete since it doesn't cover all edge cases and isn't styled. However, I hope the implementation walkthrough with plain GraphQL in React has helped you to understand using only GraphQL client-side in React using HTTP requests. I feel it's important to take this step before using a sophisticated GraphQL client library such as Apollo or Relay.
 
-I've shown how to implement a React application with GraphQL and HTTP requests without using a library like Apollo. Next, you will continue learning about using GraphQL in React using Apollo instead of basic HTTP requests with axios. The Apollo GraphQL Client makes caching your data, normalizing it, performing optimistic updates, and pagination effortless. That's not all by a long shot, so stay tuned for the next applications you are are going to build with GraphQL.
+I've shown how to implement a React application with GraphQL and HTTP requests without using a library like Apollo. Next, you will continue learning about using GraphQL in React using Apollo instead of basic HTTP requests with axios. The Apollo GraphQL Client makes caching your data, normalizing it, performing optimistic updates, and pagination effortless. That's not all by a long shot, so stay tuned for the next applications you are going to build with GraphQL.


### PR DESCRIPTION
I found a few typos / grammatical issues in the React With GraphQL chapter in the GraphQL online book. I opened an issue for it before realizing a pull request would be more appropriate. I also submitted a PR previously but had to close it due to my IDE changing some of the formatting of the index.md file. 

### Original Strings
1. The function that is passed to this.setState() can be extracted **as higher-order** function.
2. Note that the application is not built **for to be robust, but is intended only** as a learning experience.
3. Remember to adjust the name of the query variable when **its** used to perform the request.
4. Remember, a query reaches into the GraphQL graph, so we can nest the repository field in the organization when the schema **defined** the relationship between these two entities.
5. In the previous template string, the cursor is passed as variable to the query and used **as after** argument for the list field.
6. That's not all by a long shot, so stay tuned for the next applications you **are are** going to build with GraphQL.

### Changes made/typos fixed
1. The function that is passed to this.setState() can be extracted **as a higher-order** function.
2. Note that the application is not built **to be robust, it is only** intended as a learning experience.
3. Remember to adjust the name of the query variable when **it's** used to perform the request.
4. Remember, a query reaches into the GraphQL graph, so we can nest the repository field in the organization when the schema **defines** the relationship between these two entities.
5. In the previous template string, the cursor is passed as variable to the query and used as **an** after argument for the list field.
6. That's not all by a long shot, so stay tuned for the next applications you **are** going to build with GraphQL.
