### PR TITLE
I clarified the reason for installing two packages

### DIFF
--- a/manuscript/08-apollo-server/index.md
+++ b/manuscript/08-apollo-server/index.md
@@ -19,7 +19,7 @@ Install these two dependencies to the *package.json* file and *node_modules* fol
 npm install apollo-server apollo-server-express --save
 ~~~~~~~
 
-As you can see by the library names, you can use any other middleware solution (e.g. Koa, Hapi) to complement your standalone Apollo Server. Apart from these libraries for Apollo Server, you need the core libraries for Express and GraphQL:
+As you can see by the library names, you can use any other middleware solution (e.g. Koa, Hapi) to complement your standalone Apollo Server. Apart from these libraries for Apollo Server, you need the core libraries for Express and GraphQL(Why?because they are PeerDependencies and aren't dependencies):
 
 {title="Command Line",lang="json"}
 ~~~~~~~


### PR DESCRIPTION
since "express" and "GraphQL" are peer Dependencies for "Apollo-server" and "Apollo-server-express", it might make a question that if these packages used them Internally why do we need install them? so i referred to its reason.